### PR TITLE
fixes issue for scaleio interface on non-homogenius clusters

### DIFF
--- a/roles/openstack-controllers/handlers/main.yml
+++ b/roles/openstack-controllers/handlers/main.yml
@@ -6,8 +6,9 @@
   command: pcs resource disable cinder-api --wait 30
   run_once: true
   notify: pacemaker enable cinder-api
+  when: use_pacemaker
 
 - name: pacemaker enable cinder-api
   command: pcs resource enable cinder-api --wait 30
   run_once: true
-
+  when: use_pacemaker

--- a/roles/openstack-controllers/tasks/redhat.yml
+++ b/roles/openstack-controllers/tasks/redhat.yml
@@ -52,5 +52,5 @@
     - { section: "scaleio", option: "round_volume_capacity", value: "True" }
     - { section: "scaleio", option: "force_delete", value: "True" }
     - { section: "scaleio", option: "unmap_volume_before_deletion", value: "True" } 
-  notify: pacemaker disable cinder-api
+#  notify: pacemaker disable cinder-api
 

--- a/roles/sds/tasks/main.yml
+++ b/roles/sds/tasks/main.yml
@@ -57,7 +57,7 @@
   command: >
     scli --add_sds
     --mdm_ip {{ scaleio_mdm_primary_ip }},{{ scaleio_mdm_secondary_ip }}
-    --sds_ip {{ hostvars[inventory_hostname]['ansible_'+scaleio_interface]['ipv4']['address'] }}
+    --sds_ip {{ hostvars[inventory_hostname]['ansible_'+hostvars[inventory_hostname]['scaleio_interface']]['ipv4']['address'] }}
     --storage_pool_name {{ scaleio_storage_pool }}
     --device_path {{ disks.ansible_available_disks|join(',') }}
     --sds_name "{{ inventory_hostname }}"


### PR DESCRIPTION
Update to ansible-scaleio 
Fixes issue if pacemaker is not present
fixes issue if scaleio interface is not the same on all systems.
