### PR TITLE
ansible-scaleio detangle

### DIFF
--- a/inventory/group_vars/all/common.yml
+++ b/inventory/group_vars/all/common.yml
@@ -1,6 +1,8 @@
+---
+# Scaleio deployment variables
 scaleio_license:
 
-scaleio_mgmt_interface: em3 
+scaleio_mgmt_interface: em3
 scaleio_interface: bond0.1803
 
 scaleio_base_package_name: EMC-ScaleIO
@@ -29,13 +31,13 @@ scaleio_callhome_config:
 
 
 scaleio_mdm_primary_ip: "{{ hostvars[groups['mdm'][0]]['ansible_'+scaleio_interface]['ipv4']['address'] }}"
-scaleio_mdm_primary_mgmt_ip: "{{ hostvars[groups['mdm'][0]]['ansible_'+scaleio_mgmt_interface]['ipv4']['address'] }}" 
+scaleio_mdm_primary_mgmt_ip: "{{ hostvars[groups['mdm'][0]]['ansible_'+scaleio_mgmt_interface]['ipv4']['address'] }}"
 
 scaleio_mdm_secondary_ip: "{{ hostvars[groups['mdm'][1]]['ansible_'+scaleio_interface]['ipv4']['address'] }}"
 scaleio_mdm_secondary_mgmt_ip: "{{ hostvars[groups['mdm'][1]]['ansible_'+scaleio_mgmt_interface]['ipv4']['address'] }}"
 
-# This IP address is either a single system or a VIP for HAproxy e.g. in OpenStack 
-scaleio_gateway_ip: 
+# This IP address is either a single system or a VIP for HAproxy e.g. in OpenStack
+scaleio_gateway_ip:
 
 scaleio_tb_ip: "{{ hostvars[groups['tb'][0]]['ansible_'+scaleio_interface]['ipv4']['address'] }}"
 

--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -1,28 +1,30 @@
-[mdm]
-scale-1 
-scale-2 
-
-[tb]
-scale-3 
-
-[sds:children]
-mdm
-tb
+localhost ansible_connection=local
 
 [gateway:children]
 mdm
 tb
 #controller
 
-[compute]
-cmp-1 
+[mdm]
+scaleio-1
+scaleio-2
 
 [sdc:children]
 sds
 gateway
 compute
 
+[sds:children]
+mdm
+tb
+
+[tb]
+scaleio-3
+
+[compute]
+compute-1
+
 [controller]
-ctlr-1
-ctlr-2
-ctlr-3
+controller-1
+controller-2
+controller-3

--- a/roles/prep-scaleio/defaults/main.yml
+++ b/roles/prep-scaleio/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# Openstack release for extracting driver zip file
+openstack_release: 'juno'
+
+# The name of the EMC SCaleIO files downloaded from EMC. Currently only version
+# 1.32.2 is supported.
+scaleio_files:
+  - ScaleIO_1.32.2_Gateway_for_Linux_Download.zip
+  - ScaleIO_1.32.2_OpenStack_Driver_Download.zip
+  - ScaleIO_1.32.2_RHEL7_Download.zip

--- a/roles/prep-scaleio/tasks/main.yml
+++ b/roles/prep-scaleio/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+# The prep-scaleio play will take the scaleio software zip file, extract and copy
+# the files to the ansible-scaleio project directories as needed.
+
+# The check for these files is done in separate tasks to make debugging easier.
+
+- name: Check if the {{ scaleio_files[0] }} file exists in /opt/autodeploy/resources/scaleio
+  stat:
+    path: "{{ scaleio_path }}/{{ scaleio_files[0] }}"
+  register: rhel_zip
+
+- name: Is the {{ scaleio_files[0] }} file available
+  fail: msg=" The {{ scaleio_files[0] }} file has not been downloaded, please verify all required files have been downloaded and rerun the play "
+  when: not (rhel_zip.stat.exists)
+
+- name: Check if the {{ scaleio_files[1] }} file exists in /opt/autodeploy/resources/scaleio
+  stat:
+    path: "{{ scaleio_path }}/{{ scaleio_files[1] }}"
+  register: gateway_zip
+
+- name: Is the {{ scaleio_files[1] }} file available
+  fail: msg=" The {{ scaleio_files[1] }} file has not been downloaded, please verify all required files have been downloaded and rerun the play "
+  when: not (gateway_zip.stat.exists)
+
+- name: Check if the {{ scaleio_files[2] }} file exists in /opt/autodeploy/resources/scaleio
+  stat:
+    path: "{{ scaleio_path }}/{{ scaleio_files[2] }}"
+  register: osd_zip
+
+- name: Is the {{ scaleio_files[2] }} file available
+  fail: msg=" The {{ scaleio_files[2] }} file has not been downloaded, please verify all required files have been downloaded and rerun the play "
+  when: not (osd_zip.stat.exists)
+
+- name: Extract the ScaleIO source files
+  unarchive:
+    src: "{{ scaleio_path }}/{{ item }}"
+    dest: "{{ scaleio_path }}"
+  with_items: scaleio_files
+
+- name: Find the extracted RPM files
+  shell: 'find {{ scaleio_path }} -type f -name "*.rpm"'
+  register: rpm_files
+
+- name: Copy the RPMs to the ansible-scaleio project
+  copy:
+    src: "{{ item }}"
+    dest: "{{ scaleio_rpm_path }}"
+  with_items: rpm_files.stdout_lines
+
+- name: Find the OpenStack Release driver zip files
+  shell: 'find {{ scaleio_path }} -type f -name "*{{ openstack_release }}*.zip"'
+  register: osd_files
+
+- name: Extract the OpenStack Release driver files to the openstack-compute role
+  unarchive:
+    src: "{{ item }}"
+    dest: "{{ scaleio_compute_path }}"
+  with_items: osd_files.stdout
+
+- name: Extract the OpenStack Release driver files to the openstack-controllers role
+  unarchive:
+    src: "{{ item }}"
+    dest: "{{ scaleio_controllers_path }}"
+  with_items: osd_files.stdout

--- a/roles/prep-scaleio/vars/main.yml
+++ b/roles/prep-scaleio/vars/main.yml
@@ -1,0 +1,7 @@
+---
+# These are the variables for the prep-scaleio role.
+ansible_scaleio_path: "{{ projects_base_path }}/ansible-scaleio"
+scaleio_rpm_path: "{{ ansible_scaleio_path }}/files/"
+scaleio_compute_path: "{{ ansible_scaleio_path }}/roles/openstack-compute/files/"
+scaleio_controllers_path: "{{ ansible_scaleio_path }}/roles/openstack-controllers/files/"
+scaleio_path: "{{ resources_base_path }}/scaleio"

--- a/site.yml
+++ b/site.yml
@@ -1,4 +1,11 @@
 ---
+# This playbook will deploy and configure EMC ScaleIO for use with RHOSP.
+
+- name: Prepare for install
+  hosts: localhost
+  roles:
+  - prep-scaleio
+
 - name: Install Common
   hosts: scaleio
   tags: common


### PR DESCRIPTION
This PR creates a role to prep the scaleio project by extracting scaleio files and putting them in the correct location within the project.

```
PLAY [Stage DCAF automation resources on autodeploynode] **********************

GATHERING FACTS ***************************************************************
ok: [autodeploynode]

TASK: [prep-projects | Check if the ScaleIO_1.32.2_Gateway_for_Linux_Download.zip file exists in /opt/autodeploy/resources/scaleio] ***
ok: [autodeploynode]

TASK: [prep-projects | Is the ScaleIO_1.32.2_Gateway_for_Linux_Download.zip file available] ***
skipping: [autodeploynode]

TASK: [prep-projects | Check if the ScaleIO_1.32.2_OpenStack_Driver_Download.zip file exists in /opt/autodeploy/resources/scaleio] ***
ok: [autodeploynode]

TASK: [prep-projects | Is the ScaleIO_1.32.2_OpenStack_Driver_Download.zip file available] ***
skipping: [autodeploynode]

TASK: [prep-projects | Check if the ScaleIO_1.32.2_RHEL7_Download.zip file exists in /opt/autodeploy/resources/scaleio] ***
ok: [autodeploynode]

TASK: [prep-projects | Is the ScaleIO_1.32.2_RHEL7_Download.zip file available] ***
skipping: [autodeploynode]

TASK: [prep-projects | Extract the ScaleIO source files] **********************
changed: [autodeploynode] => (item=ScaleIO_1.32.2_Gateway_for_Linux_Download.zip)
changed: [autodeploynode] => (item=ScaleIO_1.32.2_OpenStack_Driver_Download.zip)
changed: [autodeploynode] => (item=ScaleIO_1.32.2_RHEL7_Download.zip)

TASK: [prep-projects | Find the extracted RPM files] **************************
changed: [autodeploynode]

TASK: [prep-projects | Copy the RPMs to the ansible-scaleio project] **********
changed: [autodeploynode] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_Gateway_for_Linux_Download/EMC-ScaleIO-gateway-1.32-2451.4.noarch.rpm)
changed: [autodeploynode] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-sds-1.32-2451.4.el7.x86_64.rpm)
changed: [autodeploynode] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-lia-1.32-2451.4.el7.x86_64.rpm)
changed: [autodeploynode] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-mdm-1.32-2451.4.el7.x86_64.rpm)
changed: [autodeploynode] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-callhome-1.32-2451.4.el7.x86_64.rpm)
changed: [autodeploynode] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-tb-1.32-2451.4.el7.x86_64.rpm)
changed: [autodeploynode] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-sdc-1.32-2451.4.el7.x86_64.rpm)

TASK: [prep-projects | Find the OpenStack Release driver zip files] ***********
changed: [autodeploynode]

TASK: [prep-projects | Extract the OpenStack Release driver files to the openstack-compute role] ***
changed: [autodeploynode] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_OpenStack_Driver_Download/EMC-ScaleIO-openstack-driver-1.32-2451.4-juno.zip)

TASK: [prep-projects | Extract the OpenStack Release driver files to the openstack-controllers role] ***
changed: [autodeploynode] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_OpenStack_Driver_Download/EMC-ScaleIO-openstack-driver-1.32-2451.4-juno.zip)

PLAY RECAP ********************************************************************
autodeploynode             : ok=10   changed=6    unreachable=0    failed=0
```
