### PR TITLE
example hosts.ini for project

### DIFF
--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -1,13 +1,24 @@
 localhost ansible_connection=local
 
+# This group is a parent group that includes all other groups. It is used as a
+# global group for things required by all hosts (variables and tasks).
+[ansible_scaleio:children]
+mdm
+tb
+gateway
+sdc
+sds
+
+# Add the host(s) that will perform the MDM role
+[mdm]
+
+# Add the host(s) that will perform the TB role
+[tb]
+
 [gateway:children]
 mdm
 tb
-#controller
-
-[mdm]
-scaleio-1
-scaleio-2
+controller
 
 [sdc:children]
 sds
@@ -18,13 +29,8 @@ compute
 mdm
 tb
 
-[tb]
-scaleio-3
-
+# Add the host(s) that will perform the RHOSP compute role
 [compute]
-compute-1
 
+# Add the host(s) that will perform the RHOSP controller role
 [controller]
-controller-1
-controller-2
-controller-3


### PR DESCRIPTION
Added a global group and comments. The global group for our purposes allows us to use the /projects/inventory/group_vars/ansible_scaleio variables
